### PR TITLE
[FEAT]#10 이메일 전송 기능 구현 및 기사 할당과 통합

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
+	// dotenv
+	testImplementation 'io.github.cdimascio:dotenv-java:3.0.0'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -35,12 +35,14 @@ dependencies {
 	// spring mongodb
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo:4.4.0'
+	//  mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	// lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
-
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/example/whiplash/article/document/Article.java
+++ b/src/main/java/com/example/whiplash/article/document/Article.java
@@ -16,6 +16,7 @@ public class Article {
     @Id @GeneratedValue
     private String id;
     private String title;
+    private String press;
     private LocalDateTime publishedAt;
     private Category category;
 }

--- a/src/main/java/com/example/whiplash/article/document/SummarizedArticle.java
+++ b/src/main/java/com/example/whiplash/article/document/SummarizedArticle.java
@@ -21,7 +21,7 @@ public class SummarizedArticle {
     @Id
     private String id;
 
-    @Indexed(unique = true)
+//    @Indexed(unique = true)
     private String originalArticleId;
 
     private String title;

--- a/src/main/java/com/example/whiplash/article/entity/SummarizedArticleIndex.java
+++ b/src/main/java/com/example/whiplash/article/entity/SummarizedArticleIndex.java
@@ -18,5 +18,5 @@ public class SummarizedArticleIndex {
     private String press;
     private LocalDateTime publishedAt;
     private LocalDateTime createdAt;
-    private String mongoId;
+    private String originalMongoId;
 }

--- a/src/main/java/com/example/whiplash/article/entity/UserArticleAssignment.java
+++ b/src/main/java/com/example/whiplash/article/entity/UserArticleAssignment.java
@@ -31,4 +31,8 @@ public class UserArticleAssignment {
     private EmailSendStatus sendStatus;
 
     private LocalDateTime assignedAt;
+
+    public void updateStatus(EmailSendStatus status) {
+        this.sendStatus = status;
+    }
 }

--- a/src/main/java/com/example/whiplash/article/repository/ArticleInitializer.java
+++ b/src/main/java/com/example/whiplash/article/repository/ArticleInitializer.java
@@ -20,12 +20,14 @@ import com.example.whiplash.user.repository.UserRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Profile("dev")
 @Slf4j
 @RequiredArgsConstructor
 @Component

--- a/src/main/java/com/example/whiplash/article/repository/ArticleInitializer.java
+++ b/src/main/java/com/example/whiplash/article/repository/ArticleInitializer.java
@@ -105,7 +105,7 @@ public class ArticleInitializer {
                     User.builder().name("Alice").email("alice@test.com").age(25).role(Role.USER).summaryLevel(SummaryLevel.SHORT).build(),
                     User.builder().name("Bob").email("bob@test.com").age(30).role(Role.USER).summaryLevel(SummaryLevel.SHORT).build(),
                     User.builder().name("Charlie").email("charlie@test.com").age(28).role(Role.USER).summaryLevel(SummaryLevel.MEDIUM).build(),
-                    User.builder().name("David").email("david@test.com").age(35).role(Role.USER).summaryLevel(SummaryLevel.MEDIUM).build(),
+                    User.builder().name("David").email("rmsghchl0@naver.com").age(35).role(Role.USER).summaryLevel(SummaryLevel.MEDIUM).build(),
                     User.builder().name("Eve").email("eve@test.com").age(27).role(Role.USER).summaryLevel(SummaryLevel.MEDIUM).build()
             );
             userRepository.saveAll(users);

--- a/src/main/java/com/example/whiplash/article/repository/ArticleInitializer.java
+++ b/src/main/java/com/example/whiplash/article/repository/ArticleInitializer.java
@@ -53,6 +53,7 @@ public class ArticleInitializer {
             Article newArticle = Article.builder()
                     .title(title1)
                     .category(category)
+                    .press("jtbc")
                     .publishedAt(publishedAt)
                     .build();
             return articleRepository.save(newArticle);
@@ -65,7 +66,7 @@ public class ArticleInitializer {
                     .press(press)
                     .publishedAt(publishedAt)
                     .createdAt(LocalDateTime.now())
-                    .mongoId(article.getId())
+                    .originalMongoId(article.getId())
                     .build();
             summarizedArticleIndexRepository.save(summarizedArticleIndex);
         }

--- a/src/main/java/com/example/whiplash/article/repository/UserArticleAssignmentRepository.java
+++ b/src/main/java/com/example/whiplash/article/repository/UserArticleAssignmentRepository.java
@@ -1,6 +1,7 @@
 package com.example.whiplash.article.repository;
 
 import com.example.whiplash.article.entity.UserArticleAssignment;
+import com.example.whiplash.domain.entity.history.email.EmailSendStatus;
 import com.example.whiplash.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,5 @@ import java.util.List;
 
 public interface UserArticleAssignmentRepository extends JpaRepository<UserArticleAssignment, Long> {
     List<UserArticleAssignment> findAllByUser(User user);
+    List<UserArticleAssignment> findAllBySendStatus(EmailSendStatus sendStatus);
 }

--- a/src/main/java/com/example/whiplash/delivery/assignment/ArticleAssigner.java
+++ b/src/main/java/com/example/whiplash/delivery/assignment/ArticleAssigner.java
@@ -1,4 +1,4 @@
-package com.example.whiplash.delivery.assginment;
+package com.example.whiplash.delivery.assignment;
 
 import com.example.whiplash.article.entity.UserArticleAssignment;
 

--- a/src/main/java/com/example/whiplash/delivery/assignment/ArticleAssignerV1.java
+++ b/src/main/java/com/example/whiplash/delivery/assignment/ArticleAssignerV1.java
@@ -1,24 +1,19 @@
-package com.example.whiplash.delivery.assginment;
+package com.example.whiplash.delivery.assignment;
 
-import com.example.whiplash.article.document.Article;
 import com.example.whiplash.article.document.Category;
 import com.example.whiplash.article.document.SummarizedArticle;
 import com.example.whiplash.article.entity.UserArticleAssignment;
-import com.example.whiplash.article.repository.ArticleRepository;
 import com.example.whiplash.article.repository.SummarizedArticleRepository;
 import com.example.whiplash.article.repository.UserArticleAssignmentRepository;
-import com.example.whiplash.domain.entity.UserKeyword;
 import com.example.whiplash.domain.entity.history.email.EmailSendStatus;
 import com.example.whiplash.domain.entity.history.email.SummaryLevel;
 import com.example.whiplash.domain.repository.InvestorProfileRepository;
 import com.example.whiplash.domain.repository.UserKeywordRepository;
 import com.example.whiplash.user.User;
 import com.example.whiplash.user.repository.UserRepository;
-import com.example.whiplash.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/src/main/java/com/example/whiplash/delivery/assignment/ArticleAssignerV1.java
+++ b/src/main/java/com/example/whiplash/delivery/assignment/ArticleAssignerV1.java
@@ -90,7 +90,7 @@ public class ArticleAssignerV1 implements ArticleAssigner{
                         .user(user)
                         .assignedAt(now)
                         .summarizedArticleId(summary.getId())
-                        .sendStatus(EmailSendStatus.PENDING)
+                        .sendStatus(EmailSendStatus.NEED_TO_SEND)
                         .build());
             }
         }

--- a/src/main/java/com/example/whiplash/delivery/assignment/ArticleAssignmentService.java
+++ b/src/main/java/com/example/whiplash/delivery/assignment/ArticleAssignmentService.java
@@ -1,4 +1,4 @@
-package com.example.whiplash.delivery.assginment;
+package com.example.whiplash.delivery.assignment;
 
 import com.example.whiplash.article.entity.UserArticleAssignment;
 import com.example.whiplash.article.repository.UserArticleAssignmentRepository;

--- a/src/main/java/com/example/whiplash/delivery/assignment/UserArticleAssignmentService.java
+++ b/src/main/java/com/example/whiplash/delivery/assignment/UserArticleAssignmentService.java
@@ -2,9 +2,9 @@ package com.example.whiplash.delivery.assignment;
 
 import com.example.whiplash.article.entity.UserArticleAssignment;
 import com.example.whiplash.article.repository.UserArticleAssignmentRepository;
+import com.example.whiplash.domain.entity.history.email.EmailSendStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,12 +14,13 @@ import java.util.List;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
-public class ArticleAssignmentService {
+public class UserArticleAssignmentService {
     private final ArticleAssigner assigner;
     private final UserArticleAssignmentRepository assignmentRepository;
 
+    // create
 //    @Scheduled(cron = "0 0 18 * * *", zone = "Asia/Seoul")
-    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")   // TODO: 로컬 테스트용
+//    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")   // TODO: 로컬 테스트용
     @Transactional
     public void assign() {
         log.info("----사용자에게 기사 할당 작업: 시작");
@@ -32,4 +33,18 @@ public class ArticleAssignmentService {
         log.info("----사용자에게 기사 할당 작업: 종료");
 
     }
+
+    // read
+    public List<UserArticleAssignment> getArticleAssignmentsByStatus(EmailSendStatus status) {
+        return assignmentRepository.findAllBySendStatus(status);
+    }
+
+    // update
+    @Transactional
+    public void updateAssignmentStatus(List<Long> assignmentIds, EmailSendStatus status) {
+        assignmentRepository.findAllById(assignmentIds).forEach(assignment -> {
+            assignment.updateStatus(status);
+        });
+    }
+
 }

--- a/src/main/java/com/example/whiplash/delivery/dispatch/ScheduledDispatchStrategy.java
+++ b/src/main/java/com/example/whiplash/delivery/dispatch/ScheduledDispatchStrategy.java
@@ -17,7 +17,7 @@ public class ScheduledDispatchStrategy implements DispatchStrategy {
      * cron 표현식은 application.yml 에서 dispatch.scheduled.cron 으로 정의
      */
     @Override
-//    @Scheduled(cron = "${dispatch.scheduled.cron}")
+    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
     public void dispatchAll() {
         orchestrator.dispatchAll();
     }

--- a/src/main/java/com/example/whiplash/delivery/email/EmailSender.java
+++ b/src/main/java/com/example/whiplash/delivery/email/EmailSender.java
@@ -1,5 +1,7 @@
 package com.example.whiplash.delivery.email;
 
+import java.util.List;
+
 public interface EmailSender {
-    void send();
+    void sendSummarizedArticle(Long userId, List<String> summarizedArticleIds);
 }

--- a/src/main/java/com/example/whiplash/delivery/email/EmailSender.java
+++ b/src/main/java/com/example/whiplash/delivery/email/EmailSender.java
@@ -3,5 +3,5 @@ package com.example.whiplash.delivery.email;
 import java.util.List;
 
 public interface EmailSender {
-    void sendSummarizedArticle(Long userId, List<String> summarizedArticleIds);
+    void sendSummarizedArticlesToUser(String email, List<String> summarizedArticleIds);
 }

--- a/src/main/java/com/example/whiplash/delivery/email/EmailSendingService.java
+++ b/src/main/java/com/example/whiplash/delivery/email/EmailSendingService.java
@@ -1,5 +1,6 @@
 package com.example.whiplash.delivery.email;
 
+import com.example.whiplash.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,9 +12,17 @@ import java.util.List;
 @Component
 public class EmailSendingService {
     private final EmailSender emailSender;
+    private final UserRepository userRepository;
 
     public void sendSummarizedArticlesToUser(Long userId, List<String> summarizedArticleIds) {
-        emailSender.sendSummarizedArticle(userId, summarizedArticleIds);
+        String email = getEmail(userId);
+        emailSender.sendSummarizedArticlesToUser(email, summarizedArticleIds);
+    }
+
+    private String getEmail(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("there is no user with id: " + userId))
+                .getEmail();
     }
 
 

--- a/src/main/java/com/example/whiplash/delivery/email/EmailSendingService.java
+++ b/src/main/java/com/example/whiplash/delivery/email/EmailSendingService.java
@@ -1,7 +1,20 @@
 package com.example.whiplash.delivery.email;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 @Component
 public class EmailSendingService {
+    private final EmailSender emailSender;
+
+    public void sendSummarizedArticlesToUser(Long userId, List<String> summarizedArticleIds) {
+        emailSender.sendSummarizedArticle(userId, summarizedArticleIds);
+    }
+
+
 }

--- a/src/main/java/com/example/whiplash/delivery/email/SmtpEmailSender.java
+++ b/src/main/java/com/example/whiplash/delivery/email/SmtpEmailSender.java
@@ -18,20 +18,16 @@ import java.util.stream.Collectors;
 public class SmtpEmailSender implements EmailSender {
 
     private final JavaMailSender mailSender;
-    private final UserRepository userRepository;
     private final SummarizedArticleRepository summarizedArticleRepository;
 
     @Override
-    public void sendSummarizedArticle(Long userId, List<String> summarizedArticleIds) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));    //TODO: 예외처리 모듈 가져오기
-
+    public void sendSummarizedArticlesToUser(String email, List<String> summarizedArticleIds) {
         List<SummarizedArticle> articles = summarizedArticleRepository.findAllById(summarizedArticleIds);
 
         String content = transformSummaryToContent(articles);
 
         SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(user.getEmail());
+        message.setTo(email);
         message.setSubject("오늘의 요약 뉴스입니다");
         message.setText(content);
 

--- a/src/main/java/com/example/whiplash/delivery/email/SmtpEmailSender.java
+++ b/src/main/java/com/example/whiplash/delivery/email/SmtpEmailSender.java
@@ -1,8 +1,46 @@
 package com.example.whiplash.delivery.email;
 
-public class SmtpEmailSender implements EmailSender{
-    @Override
-    public void send() {
 
+import com.example.whiplash.article.document.SummarizedArticle;
+import com.example.whiplash.article.repository.SummarizedArticleRepository;
+import com.example.whiplash.user.User;
+import com.example.whiplash.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Component
+public class SmtpEmailSender implements EmailSender {
+
+    private final JavaMailSender mailSender;
+    private final UserRepository userRepository;
+    private final SummarizedArticleRepository summarizedArticleRepository;
+
+    @Override
+    public void sendSummarizedArticle(Long userId, List<String> summarizedArticleIds) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));    //TODO: 예외처리 모듈 가져오기
+
+        List<SummarizedArticle> articles = summarizedArticleRepository.findAllById(summarizedArticleIds);
+
+        String content = transformSummaryToContent(articles);
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(user.getEmail());
+        message.setSubject("오늘의 요약 뉴스입니다");
+        message.setText(content);
+
+        mailSender.send(message);
+    }
+
+    private String transformSummaryToContent(List<SummarizedArticle> articles) {
+        return articles.stream()
+                .map(article -> String.format("!! %s\n%s\n", article.getTitle(), article.getSummarizedContent()))
+                .collect(Collectors.joining("\n\n"));
     }
 }

--- a/src/main/java/com/example/whiplash/delivery/orchestrator/ArticleDeliveryOrchestrator.java
+++ b/src/main/java/com/example/whiplash/delivery/orchestrator/ArticleDeliveryOrchestrator.java
@@ -1,8 +1,7 @@
 package com.example.whiplash.delivery.orchestrator;
 
-import com.example.whiplash.delivery.assginment.ArticleAssignmentService;
+import com.example.whiplash.delivery.assignment.ArticleAssignmentService;
 import com.example.whiplash.delivery.email.EmailSendingService;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/example/whiplash/delivery/orchestrator/ArticleDeliveryOrchestrator.java
+++ b/src/main/java/com/example/whiplash/delivery/orchestrator/ArticleDeliveryOrchestrator.java
@@ -1,14 +1,20 @@
 package com.example.whiplash.delivery.orchestrator;
 
-import com.example.whiplash.delivery.assignment.ArticleAssignmentService;
+import com.example.whiplash.article.entity.UserArticleAssignment;
+import com.example.whiplash.delivery.assignment.UserArticleAssignmentService;
 import com.example.whiplash.delivery.email.EmailSendingService;
+import com.example.whiplash.domain.entity.history.email.EmailSendStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 public class ArticleDeliveryOrchestrator {
-    private final ArticleAssignmentService assignmentService;
+    private final UserArticleAssignmentService assignmentService;
     private final EmailSendingService emailService;
 
     /**
@@ -19,9 +25,30 @@ public class ArticleDeliveryOrchestrator {
         assignmentService.assign();
 
         // 2) 할당된 기사 요약 가져오기 (서브시스템/서비스로부터)
-        //    Map<Long userId, List<SummarizedArticle>> summaries = assignmentService.fetchSummaries();
+        List<UserArticleAssignment> assignments = assignmentService.getArticleAssignmentsByStatus(EmailSendStatus.NEED_TO_SEND);
+        Map<Long, List<Long>> assignmentIdsByUser = assignments.stream()
+                .collect(Collectors.groupingBy(
+                        assignment -> assignment.getUser().getId(),
+                        Collectors.mapping(assignment -> assignment.getId(), Collectors.toList())
+                ));
 
         // 3) 이메일 발송
-        //    summaries.forEach((userId, list) -> emailService.sendArticleByEmail(userId, list));
+        Map<Long, List<String>> summaryIdsByUser = assignments.stream()
+                .collect(Collectors.groupingBy(
+                        assignment -> assignment.getUser().getId(), //userId로 그룹핑
+                        Collectors.mapping(assignment -> assignment.getSummarizedArticleId(), Collectors.toList())  // 어떻게 그룹핑 할지
+                ));
+        summaryIdsByUser.forEach((userId, summaryIds) -> {
+                    emailService.sendSummarizedArticlesToUser(userId, summaryIds);                                      // 이메일 전송
+                    assignmentService.updateAssignmentStatus(assignmentIdsByUser.get(userId), EmailSendStatus.SENT);    //UserArticleAssignment 상태 변경
+                }
+        );
+
     }
+    /** TODO
+     * (옵션) 대량 트래픽 시 고려해볼 추가 최적화
+     * 페이징 처리: getArticleAssignmentsByStatus 결과가 수천 건 이상이라면 페이징 또는 배치 처리.
+     *
+     * 비동기/배치 큐: 대량 메일 발송 시, 비동기로 emailService 호출하거나 메시지 큐에 태스크를 보내는 구조로 변경.
+     */
 }

--- a/src/main/java/com/example/whiplash/domain/entity/history/email/EmailSendStatus.java
+++ b/src/main/java/com/example/whiplash/domain/entity/history/email/EmailSendStatus.java
@@ -1,5 +1,9 @@
 package com.example.whiplash.domain.entity.history.email;
 
 public enum EmailSendStatus {
-    PENDING, SENT, FAILED, CANCELLED,
+    PENDING,
+    NEED_TO_SEND,
+    SENT,
+    FAILED,
+    CANCELLED,
 }

--- a/src/main/java/com/example/whiplash/domain/entity/profile/InvestorProfile.java
+++ b/src/main/java/com/example/whiplash/domain/entity/profile/InvestorProfile.java
@@ -41,8 +41,12 @@ public class InvestorProfile {
     @Enumerated(value = STRING)
     private ExperienceLevel experienceLevel;
 
-    @ElementCollection //TODO: 값타입 매핑 확인 필요
+
+    @ElementCollection
     @Enumerated(STRING)
+    @CollectionTable(name = "investor_profile_interest_categories",
+            joinColumns = @JoinColumn(name = "investor_profile_id"))
+    @Column(name = "interest_category")
     private List<Category> interestCategories = new ArrayList<>();
 
     // 단방향: Profile → User

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/whiplash
-    username: root
-    password:
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${RDB_URL}
+    username: ${RDB_USERNAME}
+    password: ${RDB_PASSWORD}
+    driver-class-name: ${RDB_DRIVER_CLASS_NAME}
   jpa:
     hibernate:
       ddl-auto: create
@@ -14,11 +14,22 @@ spring:
     show-sql: true
   data:
     mongodb:
-      host: localhost
-      port: 27017
-      database: whiplash-mongo
+      host: ${NOSQL_HOST}
+      port: ${NOSQL_PORT}
+      database: ${NOSQL_DATABASE}
 #      username: root
 #      password:
+  mail:
+    host: ${GMAIL_HOST}
+    port: ${GMAIL_PORT}
+    username: ${GMAIL_USERNAME}
+    password: ${GMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 logging:
   level:
     org.springframework.data.mongodb.core.MongoTemplate: DEBUG

--- a/src/test/java/com/example/whiplash/WhiplashApplicationTests.java
+++ b/src/test/java/com/example/whiplash/WhiplashApplicationTests.java
@@ -1,11 +1,21 @@
 package com.example.whiplash;
 
+import io.github.cdimascio.dotenv.Dotenv;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class WhiplashApplicationTests {
 
+	@BeforeAll
+	static void setUpBeforeClass() throws Exception {
+		Dotenv env = Dotenv
+				.configure()
+				.filename(".env.test")
+				.load();
+		env.entries().forEach(e -> System.setProperty(e.getKey(), e.getValue()));
+	}
 	@Test
 	void contextLoads() {
 	}

--- a/src/test/java/com/example/whiplash/article/document/MongoCRUDTest.java
+++ b/src/test/java/com/example/whiplash/article/document/MongoCRUDTest.java
@@ -40,7 +40,6 @@ public class MongoCRUDTest {
         Article a = Article.builder()
                 .title("테스트 제목")
                 .press("jtbc")
-                .rdbId(1L)
                 .publishedAt(LocalDateTime.now())
                 .build();
         Article saved = articleRepository.save(a);
@@ -71,7 +70,6 @@ public class MongoCRUDTest {
         Article a = Article.builder()
                 .title("테스트 제목2")
                 .press("jtbc2")
-                .rdbId(2L)
                 .publishedAt(LocalDateTime.now())
                 .build();
         Article saved = articleRepository.save(a);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,22 +2,34 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/whiplash_test
     username: root
-    password:
+    password: 1111
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true
     #        default_batch_fetch_size: 100
     show-sql: true
+
+  mail:
+    host: ${GMAIL_HOST}
+    port: ${GMAIL_PORT}
+    username: ${GMAIL_USERNAME}
+    password: ${GMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 #embedded mongoDB
-  data:
-    mongodb:
-      host: localhost
-      port: 27017
-      database: test
+#  data:
+#    mongodb:
+#      host: localhost
+#      port: 27017
+#      database: test
 de:
   flapdoodle:
     mongodb:


### PR DESCRIPTION
<!-- PR제목 형식
 [PR] #Issue_number: 변경사항 간단 요약
 위의 형식을 사용하여 적어주세요
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  close #Issue_number 
  를 적어주세요 -->
close #4 
close #10 

## ✨ 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- 이메일 전송
  - 사용자에게 할당된 요약된 기사를 이메일로 전송합니다.
  - spring-boot-starter-mail을 사용하였으며 호스트는 smtp.gmail 
  - 조합과 위임을 사용하여 결합도는 낮추고 응집도를 높임
    - `EmailSendingService`는 이메일 전송에 필요한 유저 정보 등을 가져오는 넓은 범위의 책임을 가진다.  순수 이메일 전송 기능은 `SmtpEmailSender`가 담당하도록 위임.
- 환경변수 관리
  - 기존에 .yml설정 파일에 흩뿌려져 있던 중요 정보들을 .env로 하나의 환경변수 파일로 관리
  - 테스트 작성시 환경변수 등록이 필요하므로 편의를 위해 dotEnv 라이브러리 이용
## 📸 스크린샷(선택)
<!-- 이해를 돕기위해 사진을 첨부해주세요 -->
