### PR TITLE
[HOTFIX] stream 명령어 수행 시 stream-key를 jdk로 직렬화하는 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,12 +63,18 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
 	// h2
 	runtimeOnly 'com.h2database:h2'
+
 	// spring boot test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
 	// spring security test
 	testImplementation 'org.springframework.security:spring-security-test'
+
 	// TestContainer
 	testImplementation 'org.testcontainers:junit-jupiter:1.20.1'
 	testImplementation "com.redis:testcontainers-redis:2.2.2"

--- a/src/main/java/com/example/whiplash/global/config/RedisConfig.java
+++ b/src/main/java/com/example/whiplash/global/config/RedisConfig.java
@@ -41,14 +41,16 @@ public class RedisConfig {
 
         // Key는 StringSerializer
         StringRedisSerializer stringSerializer = new StringRedisSerializer();
-        template.setKeySerializer(stringSerializer);
-        template.setHashKeySerializer(stringSerializer);
-
         // Value는 JSON
-        GenericJackson2JsonRedisSerializer jsonSerializer =
-            new GenericJackson2JsonRedisSerializer();
+        GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer();
+
+        template.setKeySerializer(stringSerializer);
         template.setValueSerializer(jsonSerializer);
+        template.setHashKeySerializer(stringSerializer);
         template.setHashValueSerializer(jsonSerializer);
+
+        template.setEnableDefaultSerializer(false);
+        template.setDefaultSerializer(stringSerializer);
 
         template.afterPropertiesSet();
         return template;

--- a/src/main/java/com/example/whiplash/global/service/RedisStreamsTaskProducer.java
+++ b/src/main/java/com/example/whiplash/global/service/RedisStreamsTaskProducer.java
@@ -38,7 +38,7 @@ public class RedisStreamsTaskProducer implements ArticleTaskProducer {
 
         RecordId recordId = redisTemplate.opsForStream()
                 .add(ObjectRecord.create(STREAM_KEY, body));
-        log.info("Published articleId={} stream with recordId={}", articleId, recordId);
+        log.info("Published articleId={} stream with recordId={} stream-key: {}", articleId, recordId, STREAM_KEY);
 
         return recordId.getValue();
     }


### PR DESCRIPTION
<!-- PR제목 형식
 [PR] #Issue_number: 변경사항 간단 요약
 위의 형식을 사용하여 적어주세요
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  close #Issue_number 
  를 적어주세요 -->

## ✨ 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
### 문제상황
이전에 `KeySerializer`를 `StringSerializer`를 사용했음에도 불구하고 스트림 연산 수행 시 여전히 아래처럼 스트림 키 값이 잘못 직렬화 되는 문제가 있었음
> 127.0.0.1:6380> keys *
> 1) "processed-articles"
> 2) "\xac\xed\x00\x05t\x00\x12processed-articles"
> 3) "\xac\xed\x00\x05t\x00\x0earticle-stream"
> 4) "article-stream"

### 해결
streams 연산은 `DefaultSerializer`를 사용하는데 별도 설정이 없다면 `JdkSerializationRedisSerializer`를 사용하는게 문제이므로 해당 직렬화 구현체를 `StringSerializer`를 사용하도록 변경
## 📸 스크린샷(선택)
<!-- 이해를 돕기위해 사진을 첨부해주세요 -->
