### PR TITLE
Feature/#44 user settings of article

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,24 @@
+{
+	"mcpServers": {
+		"task-master-ai": {
+			"type": "stdio",
+			"command": "npx",
+			"args": [
+				"-y",
+				"--package=task-master-ai",
+				"task-master-ai"
+			],
+			"env": {
+				"ANTHROPIC_API_KEY": "YOUR_ANTHROPIC_API_KEY_HERE",
+				"PERPLEXITY_API_KEY": "YOUR_PERPLEXITY_API_KEY_HERE",
+				"OPENAI_API_KEY": "YOUR_OPENAI_KEY_HERE",
+				"GOOGLE_API_KEY": "YOUR_GOOGLE_KEY_HERE",
+				"XAI_API_KEY": "YOUR_XAI_KEY_HERE",
+				"OPENROUTER_API_KEY": "YOUR_OPENROUTER_KEY_HERE",
+				"MISTRAL_API_KEY": "YOUR_MISTRAL_KEY_HERE",
+				"AZURE_OPENAI_API_KEY": "YOUR_AZURE_KEY_HERE",
+				"OLLAMA_API_KEY": "YOUR_OLLAMA_API_KEY_HERE"
+			}
+		}
+	}
+}

--- a/src/main/java/com/example/whiplash/apiPayload/ErrorStatus.java
+++ b/src/main/java/com/example/whiplash/apiPayload/ErrorStatus.java
@@ -10,6 +10,7 @@ public enum ErrorStatus {
     UNAUTHORIZED("E001", "인증이 필요합니다"),
     INVALID_TOKEN("E002", "유효하지 않은 토큰입니다"),
     INVALID_PASSWORD("E003", "비밀번호가 일치하지 않습니다."),
+    FORBIDDEN("E004", "접근 권한이 없습니다"),
 
     // 사용자 관련
     USER_NOT_FOUND("U401", "사용자를 찾을 수 없습니다"),

--- a/src/main/java/com/example/whiplash/article/service/ArticleSummaryLevelService.java
+++ b/src/main/java/com/example/whiplash/article/service/ArticleSummaryLevelService.java
@@ -1,0 +1,44 @@
+package com.example.whiplash.article.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.whiplash.apiPayload.ErrorStatus;
+import com.example.whiplash.apiPayload.exception.WhiplashException;
+import com.example.whiplash.user.domain.User;
+import com.example.whiplash.user.repository.user.UserRepository;
+import com.example.whiplash.user.web.dto.request.SummaryLevelUpdateRequest;
+import com.example.whiplash.user.web.dto.response.SummaryLevelUpdateResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ArticleSummaryLevelService {
+	private final UserRepository userRepository;
+
+	@Transactional
+	public SummaryLevelUpdateResponse updateSummaryLevel(
+		SummaryLevelUpdateRequest request,
+		Optional<String> currentUserEmail) {
+		checkUserIsAuthenticated(currentUserEmail);
+
+		User user = userRepository.findByEmail(currentUserEmail.get())
+			.orElseThrow(() -> new WhiplashException(ErrorStatus.USER_NOT_FOUND));
+
+		user.updateSummaryLevel(request.summaryLevel());
+
+		return SummaryLevelUpdateResponse.of(user.getId(), user.getSummaryLevel());
+	}
+
+	private static void checkUserIsAuthenticated(Optional<String> currentUserEmail) {
+		if (currentUserEmail.isEmpty()) {
+			throw new WhiplashException(ErrorStatus.UNAUTHORIZED);
+		}
+	}
+
+
+}

--- a/src/main/java/com/example/whiplash/article/web/controller/ArticleLoadController.java
+++ b/src/main/java/com/example/whiplash/article/web/controller/ArticleLoadController.java
@@ -1,4 +1,4 @@
-package com.example.whiplash.article.controller;
+package com.example.whiplash.article.web.controller;
 
 import com.example.whiplash.apiPayload.ApiResponse;
 import com.example.whiplash.article.domain.document.SummaryStatus;
@@ -19,7 +19,7 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/articles")
-public class ArticleController {
+public class ArticleLoadController {
 
     private final ArticleQueryService articleQueryService;
 

--- a/src/main/java/com/example/whiplash/article/web/controller/ArticleSummaryLevelController.java
+++ b/src/main/java/com/example/whiplash/article/web/controller/ArticleSummaryLevelController.java
@@ -1,0 +1,34 @@
+package com.example.whiplash.article.web.controller;
+
+import com.example.whiplash.apiPayload.ApiResponse;
+import com.example.whiplash.article.service.ArticleSummaryLevelService;
+import com.example.whiplash.global.util.SecurityContextUtils;
+import com.example.whiplash.user.service.UserService;
+import com.example.whiplash.user.web.dto.request.SummaryLevelUpdateRequest;
+import com.example.whiplash.user.web.dto.response.SummaryLevelUpdateResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/articles")
+@RestController
+public class ArticleSummaryLevelController {
+
+    private final UserService userService;
+    private final ArticleSummaryLevelService articleSummaryLevelService;
+
+    @PutMapping("/summary-level")
+    public ApiResponse<SummaryLevelUpdateResponse> updateSummaryLevel(
+            @Valid @RequestBody SummaryLevelUpdateRequest request) {
+
+        SummaryLevelUpdateResponse response = articleSummaryLevelService.updateSummaryLevel(
+                request,
+                SecurityContextUtils.getCurrentUserEmail()
+        );
+
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/example/whiplash/auth/service/AuthService.java
+++ b/src/main/java/com/example/whiplash/auth/service/AuthService.java
@@ -96,7 +96,7 @@ public class AuthService {
 
     @Transactional
     public TokenResponseDTO login(LoginRequestDTO loginRequestDTO) {
-        User user = userRepository.findByEmail(loginRequestDTO.getEmail())
+        User user = userRepository.findByEmail(loginRequestDTO.email())
                 .orElseThrow(() -> new WhiplashException(ErrorStatus.USER_NOT_FOUND));
 
         log.info("첫번째 조회 ----------------");
@@ -107,7 +107,7 @@ public class AuthService {
 
         log.info("두번째 조회 ----------------");
 
-        if(!passwordEncoder.matches(loginRequestDTO.getPassword(), user.getPassword())) {
+        if(!passwordEncoder.matches(loginRequestDTO.password(), user.getPassword())) {
             throw new WhiplashException(ErrorStatus.INVALID_PASSWORD);
         }
         log.info("세번째 조회 ----------------");

--- a/src/main/java/com/example/whiplash/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/whiplash/config/security/SecurityConfig.java
@@ -1,13 +1,21 @@
 package com.example.whiplash.config.security;
 
+import com.example.whiplash.config.security.filter.LoginAuthenticationFilter;
+import com.example.whiplash.config.security.handler.LoginFailureHandler;
+import com.example.whiplash.config.security.handler.LoginSuccessHandler;
 import com.example.whiplash.config.security.jwt.JwtAuthenticationFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -19,6 +27,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final LoginSuccessHandler loginSuccessHandler;
+    private final LoginFailureHandler loginFailureHandler;
+    private final UserDetailsService customUserDetailService;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -26,7 +37,23 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public AuthenticationManager authenticationManager() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(customUserDetailService);
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return new ProviderManager(authProvider);
+    }
+
+    @Bean
+    public LoginAuthenticationFilter loginAuthenticationFilter(ObjectMapper objectMapper) {
+        LoginAuthenticationFilter filter = new LoginAuthenticationFilter(authenticationManager(), objectMapper);
+        filter.setAuthenticationSuccessHandler(loginSuccessHandler);
+        filter.setAuthenticationFailureHandler(loginFailureHandler);
+        return filter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, LoginAuthenticationFilter loginAuthenticationFilter) throws Exception {
         http
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
@@ -37,6 +64,7 @@ public class SecurityConfig {
                                         "/health",
                                         "/api/auth/register",
                                         "/api/auth/login",
+                                        "/api/login",
                                         "/api/auth/refresh",
                                         "/api/articles/**",
                                         "/swagger-ui/**",
@@ -53,7 +81,8 @@ public class SecurityConfig {
                                 .anyRequest().authenticated()
                 )
                 .csrf(AbstractHttpConfigurer::disable)
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(loginAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/example/whiplash/config/security/filter/LoginAuthenticationFilter.java
+++ b/src/main/java/com/example/whiplash/config/security/filter/LoginAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package com.example.whiplash.config.security.filter;
+
+import com.example.whiplash.user.web.dto.request.LoginRequestDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+/**
+ * 커스텀 로그인 인증 필터
+ * UsernamePasswordAuthenticationFilter를 상속받아 JSON 형식의 로그인 요청을 처리합니다.
+ */
+@Slf4j
+public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final ObjectMapper objectMapper;
+
+    public LoginAuthenticationFilter(AuthenticationManager authenticationManager, ObjectMapper objectMapper) {
+        super(authenticationManager);
+        this.objectMapper = objectMapper;
+        setFilterProcessesUrl("/api/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException {
+
+        if (!request.getMethod().equals("POST")) {
+            throw new AuthenticationServiceException("Authentication method not supported: " + request.getMethod());
+        }
+
+        try {
+            LoginRequestDTO loginRequest = objectMapper.readValue(request.getInputStream(), LoginRequestDTO.class);
+
+            log.info("로그인 시도: email={}", loginRequest.email());
+
+            UsernamePasswordAuthenticationToken authenticationToken =
+                    new UsernamePasswordAuthenticationToken(
+                            loginRequest.email(),
+                            loginRequest.password()
+                    );
+
+            return this.getAuthenticationManager().authenticate(authenticationToken);
+
+        } catch (IOException e) {
+            log.error("로그인 요청 파싱 실패", e);
+            throw new AuthenticationServiceException("로그인 요청을 파싱할 수 없습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/example/whiplash/config/security/handler/LoginFailureHandler.java
+++ b/src/main/java/com/example/whiplash/config/security/handler/LoginFailureHandler.java
@@ -1,0 +1,61 @@
+package com.example.whiplash.config.security.handler;
+
+import com.example.whiplash.apiPayload.ApiResponse;
+import com.example.whiplash.apiPayload.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 로그인 실패 시 에러 응답을 처리하는 핸들러
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LoginFailureHandler implements AuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+
+        log.error("로그인 실패: {}", exception.getMessage());
+
+        ErrorStatus errorStatus = determineErrorStatus(exception);
+
+        ApiResponse<?> apiResponse = ApiResponse.onFailure(errorStatus);
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+
+    private ErrorStatus determineErrorStatus(AuthenticationException exception) {
+        if (exception instanceof BadCredentialsException) {
+            return ErrorStatus.INVALID_PASSWORD;
+        } else if (exception instanceof UsernameNotFoundException ||
+                   exception instanceof InternalAuthenticationServiceException) {
+            return ErrorStatus.USER_NOT_FOUND;
+        } else if (exception instanceof DisabledException) {
+            return ErrorStatus.USER_NOT_ACTIVATED;
+        } else {
+            return ErrorStatus.UNAUTHORIZED;
+        }
+    }
+}

--- a/src/main/java/com/example/whiplash/config/security/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/example/whiplash/config/security/handler/LoginSuccessHandler.java
@@ -1,0 +1,62 @@
+package com.example.whiplash.config.security.handler;
+
+import com.example.whiplash.apiPayload.ApiResponse;
+import com.example.whiplash.auth.service.RefreshTokenService;
+import com.example.whiplash.config.security.jwt.JwtTokenProvider;
+import com.example.whiplash.user.domain.UserStatus;
+import com.example.whiplash.user.web.dto.response.TokenResponseDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 로그인 성공 시 JWT 토큰을 생성하고 응답하는 핸들러
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+
+        log.info("로그인 성공: user={}", authentication.getName());
+
+        // JWT 토큰 생성
+        String accessToken = jwtTokenProvider.generateAccessToken(authentication);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(authentication);
+
+        // Refresh Token 저장
+        refreshTokenService.saveRefreshToken(refreshToken);
+
+        // 응답 데이터 생성
+        TokenResponseDTO tokenResponse = TokenResponseDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .userStatus(UserStatus.ACTIVE)
+                .build();
+
+        ApiResponse<TokenResponseDTO> apiResponse = ApiResponse.onSuccess(tokenResponse);
+
+        // JSON 응답 작성
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+}

--- a/src/main/java/com/example/whiplash/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/whiplash/config/security/jwt/JwtAuthenticationFilter.java
@@ -51,6 +51,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 공개 API 경로들
         String[] excludePaths = {
+                "/api/login",
                 "/api/auth/login",
                 "/api/auth/register",
                 "/api/auth/refresh",

--- a/src/main/java/com/example/whiplash/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/whiplash/global/config/SwaggerConfig.java
@@ -1,0 +1,95 @@
+package com.example.whiplash.global.config;
+
+import java.util.List;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.example.whiplash.user.web.dto.request.LoginRequestDTO;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "Bearer Authentication";
+
+    @Bean
+    public OpenAPI openAPI() {
+        OpenAPI openAPI = new OpenAPI()
+            .info(apiInfo())
+            .addSecurityItem(securityRequirement())
+            .components(components());
+
+        addLoginEndpoint(openAPI);
+
+        return openAPI;
+    }
+
+    private static void addLoginEndpoint(OpenAPI openAPI) {
+        // ✅ /api/login 엔드포인트 수동 추가
+        // LoginRequest 스키마 정의
+        Schema<?> loginSchema = new Schema<>()
+            .type("object")
+            .addProperty("email", new Schema<>()
+                .type("string")
+                .format("email")
+                .description("사용자 이메일")
+                .example("user@example.com"))
+            .addProperty("password", new Schema<>()
+                .type("string")
+                .format("password")
+                .description("사용자 비밀번호")
+                .example("password123"))
+            .required(List.of("email", "password"));
+
+        openAPI.path("/api/login", new PathItem()
+            .post(new Operation()
+                .summary("로그인")
+                .description("이메일과 비밀번호로 로그인합니다. (Spring Security Filter가 실제 처리)")
+                .requestBody(new RequestBody()
+                    .content(new Content().addMediaType("application/json",
+                        new MediaType().schema(loginSchema))))
+                .responses(new io.swagger.v3.oas.models.responses.ApiResponses()
+                    .addApiResponse("200", new ApiResponse().description("성공"))
+                    .addApiResponse("401", new ApiResponse().description("인증 실패"))
+                    .addApiResponse("400", new ApiResponse().description("잘못된 요청")))));
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Whiplash API")
+                .description("Whiplash 백엔드 API 문서")
+                .version("1.0.0");
+    }
+
+    private SecurityRequirement securityRequirement() {
+        return new SecurityRequirement()
+                .addList(SECURITY_SCHEME_NAME);
+    }
+
+    private Components components() {
+        return new Components()
+                .addSecuritySchemes(SECURITY_SCHEME_NAME, securityScheme());
+    }
+
+    private SecurityScheme securityScheme() {
+        return new SecurityScheme()
+                .name(SECURITY_SCHEME_NAME)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .description("JWT 토큰을 입력하세요 (Bearer 접두사 없이)");
+    }
+}

--- a/src/main/java/com/example/whiplash/user/service/UserKeywordService.java
+++ b/src/main/java/com/example/whiplash/user/service/UserKeywordService.java
@@ -1,0 +1,121 @@
+package com.example.whiplash.user.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.whiplash.apiPayload.ErrorStatus;
+import com.example.whiplash.apiPayload.exception.WhiplashException;
+import com.example.whiplash.user.domain.User;
+import com.example.whiplash.user.domain.keyword.Keyword;
+import com.example.whiplash.user.domain.keyword.UserKeyword;
+import com.example.whiplash.user.repository.keyword.KeywordRepository;
+import com.example.whiplash.user.repository.keyword.UserKeywordRepository;
+import com.example.whiplash.user.repository.user.UserRepository;
+import com.example.whiplash.user.web.dto.request.UserKeywordBulkCreateRequest;
+import com.example.whiplash.user.web.dto.request.UserKeywordDeleteRequest;
+import com.example.whiplash.user.web.dto.response.UserKeywordBulkCreateResponse;
+import com.example.whiplash.user.web.dto.response.UserKeywordDTO;
+import com.example.whiplash.user.web.dto.response.UserKeywordListResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class UserKeywordService {
+	private final UserRepository userRepository;
+	private final KeywordRepository keywordRepository;
+	private final UserKeywordRepository userKeywordRepository;
+
+	public UserKeywordListResponse getUserKeywords(Optional<String> currentUserEmail) {
+		checkUserIsAuthenticated(currentUserEmail);
+
+		User user = userRepository.findByEmail(currentUserEmail.get())
+			.orElseThrow(() -> new WhiplashException(ErrorStatus.USER_NOT_FOUND));
+
+		List<UserKeyword> userKeywords = userKeywordRepository.findAllByUserOrderByPriority(user);
+
+		List<UserKeywordDTO> keywordDTOs = userKeywords.stream()
+			.map(uk -> UserKeywordDTO.of(
+				uk.getId(),
+				uk.getKeywordName(),
+				uk.getPriority()
+			))
+			.toList();
+
+		return UserKeywordListResponse.of(keywordDTOs);
+	}
+
+	@Transactional
+	public UserKeywordBulkCreateResponse createUserKeywords(
+		UserKeywordBulkCreateRequest request,
+		Optional<String> currentUserEmail) {
+		checkUserIsAuthenticated(currentUserEmail);
+
+		User user = userRepository.findByEmail(currentUserEmail.get())
+			.orElseThrow(() -> new WhiplashException(ErrorStatus.USER_NOT_FOUND));
+
+		List<UserKeyword> createdKeywords = new ArrayList<>();
+
+		for (String keywordName : request.keywords()) {
+			Optional<Keyword> optionalKeyword = keywordRepository.findByName(keywordName);
+			UserKeyword userKeyword;
+
+			if (optionalKeyword.isPresent()) {
+				userKeyword = userKeywordRepository.save(UserKeyword.create(user, optionalKeyword.get()));
+			} else {
+				Keyword keyword = keywordRepository.save(Keyword.create(keywordName));
+				userKeyword = userKeywordRepository.save(UserKeyword.create(user, keyword));
+			}
+
+			createdKeywords.add(userKeyword);
+		}
+
+		List<UserKeywordDTO> keywordDTOs = createdKeywords.stream()
+			.map(uk -> UserKeywordDTO.of(
+				uk.getId(),
+				uk.getKeywordName(),
+				uk.getPriority()
+			))
+			.toList();
+
+		return UserKeywordBulkCreateResponse.of(createdKeywords.size(), keywordDTOs);
+	}
+
+	@Transactional
+	public void deleteUserKeywords(
+		UserKeywordDeleteRequest request,
+		Optional<String> currentUserEmail) {
+		checkUserIsAuthenticated(currentUserEmail);
+
+		User user = userRepository.findByEmail(currentUserEmail.get())
+			.orElseThrow(() -> new WhiplashException(ErrorStatus.USER_NOT_FOUND));
+
+		List<UserKeyword> userKeywords = userKeywordRepository.findAllById(request.userKeywordIds());
+
+		// 요청된 UserKeyword가 현재 사용자의 것인지 검증
+		checkUserIsOwnerOfUserKeywords(userKeywords, user);
+
+		userKeywordRepository.deleteAll(userKeywords);
+	}
+
+	private static void checkUserIsOwnerOfUserKeywords(List<UserKeyword> userKeywords, User user) {
+		for (UserKeyword userKeyword : userKeywords) {
+			if (!userKeyword.getUser().getId().equals(user.getId())) {
+				throw new WhiplashException(ErrorStatus.FORBIDDEN);
+			}
+		}
+	}
+
+	private static void checkUserIsAuthenticated(Optional<String> currentUserEmail) {
+		if (currentUserEmail.isEmpty()) {
+			throw new WhiplashException(ErrorStatus.UNAUTHORIZED);
+		}
+	}
+
+
+}

--- a/src/main/java/com/example/whiplash/user/web/controller/UserController.java
+++ b/src/main/java/com/example/whiplash/user/web/controller/UserController.java
@@ -1,4 +1,4 @@
-package com.example.whiplash.user.controller;
+package com.example.whiplash.user.web.controller;
 
 import com.example.whiplash.apiPayload.ApiResponse;
 import com.example.whiplash.global.util.SecurityContextUtils;

--- a/src/main/java/com/example/whiplash/user/web/controller/UserKeywordController.java
+++ b/src/main/java/com/example/whiplash/user/web/controller/UserKeywordController.java
@@ -1,0 +1,67 @@
+package com.example.whiplash.user.web.controller;
+
+import com.example.whiplash.apiPayload.ApiResponse;
+import com.example.whiplash.global.util.SecurityContextUtils;
+import com.example.whiplash.user.service.UserKeywordService;
+import com.example.whiplash.user.web.dto.request.UserKeywordBulkCreateRequest;
+import com.example.whiplash.user.web.dto.request.UserKeywordDeleteRequest;
+import com.example.whiplash.user.web.dto.response.UserKeywordBulkCreateResponse;
+import com.example.whiplash.user.web.dto.response.UserKeywordListResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/users/keywords")
+@RestController
+public class UserKeywordController {
+
+	private final UserKeywordService userKeywordService;
+
+	/**
+	 * 사용자의 키워드 조회
+	 */
+	@GetMapping
+	public ApiResponse<UserKeywordListResponse> getUserKeywords() {
+		UserKeywordListResponse response = userKeywordService.getUserKeywords(
+				SecurityContextUtils.getCurrentUserEmail()
+		);
+		return ApiResponse.onSuccess(response);
+	}
+
+	/**
+	 * 사용자의 키워드 벌크 등록
+	 */
+	@PostMapping
+	public ApiResponse<UserKeywordBulkCreateResponse> createUserKeywords(
+			@Valid @RequestBody UserKeywordBulkCreateRequest request) {
+
+		UserKeywordBulkCreateResponse response = userKeywordService.createUserKeywords(
+				request,
+				SecurityContextUtils.getCurrentUserEmail()
+		);
+
+		return ApiResponse.onCreated(response);
+	}
+
+	/**
+	 * 사용자의 키워드 벌크 삭제
+	 */
+	@DeleteMapping
+	public ApiResponse<Void> deleteUserKeywords(
+			@Valid @RequestBody UserKeywordDeleteRequest request) {
+
+		log.info("사용자 키워드 벌크 삭제 요청: count={}", request.userKeywordIds().size());
+
+		userKeywordService.deleteUserKeywords(
+				request,
+				SecurityContextUtils.getCurrentUserEmail()
+		);
+
+		log.info("사용자 키워드 벌크 삭제 완료");
+
+		return ApiResponse.onSuccess(null);
+	}
+}

--- a/src/main/java/com/example/whiplash/user/web/dto/request/LoginRequestDTO.java
+++ b/src/main/java/com/example/whiplash/user/web/dto/request/LoginRequestDTO.java
@@ -2,13 +2,13 @@ package com.example.whiplash.user.web.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
 
-@Getter
-public class LoginRequestDTO {
-    @NotBlank(message = "이메일을 입력해주세요.")
-    @Email(message = "올바른 이메일 형식이 아닙니다.")
-    private String email;
-    @NotBlank(message = "비밀번호를 입력해주세요.")
-    private String password;
+public record LoginRequestDTO(
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        String password
+) {
 }

--- a/src/main/java/com/example/whiplash/user/web/dto/request/SummaryLevelUpdateRequest.java
+++ b/src/main/java/com/example/whiplash/user/web/dto/request/SummaryLevelUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.example.whiplash.user.web.dto.request;
+
+import com.example.whiplash.domain.entity.history.email.SummaryLevel;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 사용자 요약 레벨 업데이트 요청 DTO
+ */
+public record SummaryLevelUpdateRequest(
+        @NotNull(message = "요약 레벨은 필수입니다")
+        SummaryLevel summaryLevel
+) {
+}

--- a/src/main/java/com/example/whiplash/user/web/dto/request/UserKeywordBulkCreateRequest.java
+++ b/src/main/java/com/example/whiplash/user/web/dto/request/UserKeywordBulkCreateRequest.java
@@ -1,0 +1,14 @@
+package com.example.whiplash.user.web.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+/**
+ * 사용자 키워드 벌크 등록 요청 DTO
+ */
+public record UserKeywordBulkCreateRequest(
+        @NotEmpty(message = "키워드 목록은 필수입니다")
+        List<String> keywords
+) {
+}

--- a/src/main/java/com/example/whiplash/user/web/dto/request/UserKeywordDeleteRequest.java
+++ b/src/main/java/com/example/whiplash/user/web/dto/request/UserKeywordDeleteRequest.java
@@ -1,0 +1,14 @@
+package com.example.whiplash.user.web.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+/**
+ * 사용자 키워드 삭제 요청 DTO
+ */
+public record UserKeywordDeleteRequest(
+        @NotEmpty(message = "삭제할 키워드 ID 목록은 필수입니다")
+        List<Long> userKeywordIds
+) {
+}

--- a/src/main/java/com/example/whiplash/user/web/dto/response/SummaryLevelUpdateResponse.java
+++ b/src/main/java/com/example/whiplash/user/web/dto/response/SummaryLevelUpdateResponse.java
@@ -1,0 +1,15 @@
+package com.example.whiplash.user.web.dto.response;
+
+import com.example.whiplash.domain.entity.history.email.SummaryLevel;
+
+/**
+ * 사용자 요약 레벨 업데이트 응답 DTO
+ */
+public record SummaryLevelUpdateResponse(
+        Long userId,
+        SummaryLevel summaryLevel
+) {
+    public static SummaryLevelUpdateResponse of(Long userId, SummaryLevel summaryLevel) {
+        return new SummaryLevelUpdateResponse(userId, summaryLevel);
+    }
+}

--- a/src/main/java/com/example/whiplash/user/web/dto/response/UserKeywordBulkCreateResponse.java
+++ b/src/main/java/com/example/whiplash/user/web/dto/response/UserKeywordBulkCreateResponse.java
@@ -1,0 +1,15 @@
+package com.example.whiplash.user.web.dto.response;
+
+import java.util.List;
+
+/**
+ * 사용자 키워드 벌크 등록 응답 DTO
+ */
+public record UserKeywordBulkCreateResponse(
+        int createdCount,
+        List<UserKeywordDTO> keywords
+) {
+    public static UserKeywordBulkCreateResponse of(int createdCount, List<UserKeywordDTO> keywords) {
+        return new UserKeywordBulkCreateResponse(createdCount, keywords);
+    }
+}

--- a/src/main/java/com/example/whiplash/user/web/dto/response/UserKeywordDTO.java
+++ b/src/main/java/com/example/whiplash/user/web/dto/response/UserKeywordDTO.java
@@ -1,0 +1,14 @@
+package com.example.whiplash.user.web.dto.response;
+
+/**
+ * 사용자 키워드 정보 DTO
+ */
+public record UserKeywordDTO(
+        Long userKeywordId,
+        String keywordName,
+        Integer priority
+) {
+    public static UserKeywordDTO of(Long userKeywordId, String keywordName, Integer priority) {
+        return new UserKeywordDTO(userKeywordId, keywordName, priority);
+    }
+}

--- a/src/main/java/com/example/whiplash/user/web/dto/response/UserKeywordListResponse.java
+++ b/src/main/java/com/example/whiplash/user/web/dto/response/UserKeywordListResponse.java
@@ -1,0 +1,14 @@
+package com.example.whiplash.user.web.dto.response;
+
+import java.util.List;
+
+/**
+ * 사용자 키워드 목록 조회 응답 DTO
+ */
+public record UserKeywordListResponse(
+        List<UserKeywordDTO> keywords
+) {
+    public static UserKeywordListResponse of(List<UserKeywordDTO> keywords) {
+        return new UserKeywordListResponse(keywords);
+    }
+}


### PR DESCRIPTION
<!-- PR제목 형식
 [PR] #Issue_number: 변경사항 간단 요약
 위의 형식을 사용하여 적어주세요
-->
close #44 
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  close #Issue_number 
  를 적어주세요 -->

## ✨ 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
1. 일반 id/pw 기반 로그인 기능 추가
일부 기사 관련 API 중 사용자 인증 정보를 필요로 하는 것이 있음. 이를 위해서 임시로 로그인 기능을 추가하였음.
단, 일반 회원가입 기능은 만들지 않았음.

2. 사용자가 선호하는 기사 요약 수준 설정
- 사용자는 자신이 원하는 수준의 요약 레벨을 설정할 수 있고 이를 바탕으로 *기사 일간 레포트* 및 *개인 맞춤 기사 뷰* 탭의 디폴트 요약 레벨이 결정됩니다.
- 관심 키워드 등록/수정

3. swagger config
spring security를 사용해 로그인 필터를 추가했으므로 이를 swagger 상에 임의로 추가하는 스키마 추가

## 📸 스크린샷(선택)
<!-- 이해를 돕기위해 사진을 첨부해주세요 -->
