### PR TITLE
[FEATURE]#61  맞춤 기사 전송 이메일 템플릿 변경

### DIFF
--- a/src/main/java/com/example/whiplash/article/summary/domain/document/SummarizedArticle.java
+++ b/src/main/java/com/example/whiplash/article/summary/domain/document/SummarizedArticle.java
@@ -40,13 +40,13 @@ public class SummarizedArticle {
                                            LocalDateTime summarizedAt,
                                            LocalDateTime publishedAt) {
         return SummarizedArticle.builder()
-                .originalArticleId(originalArticleId)
-                .title(title)
-                .category(category)
-                .summarizedContent(summarizedContent)
-                .summaryLevel(summaryLevel)
-                .summarizedAt(summarizedAt)
-                .publishedAt(publishedAt)
-                .build();
+            .originalArticleId(originalArticleId)
+            .title(title)
+            .category(category == null ? Category.GENERAL : category)
+            .summarizedContent(summarizedContent)
+            .summaryLevel(summaryLevel)
+            .summarizedAt(summarizedAt)
+            .publishedAt(publishedAt)
+            .build();
     }
 }

--- a/src/main/java/com/example/whiplash/delivery/assignment/ArticleAssignerV2.java
+++ b/src/main/java/com/example/whiplash/delivery/assignment/ArticleAssignerV2.java
@@ -1,29 +1,38 @@
 package com.example.whiplash.delivery.assignment;
 
-import com.example.whiplash.article.summary.domain.document.Category;
-import com.example.whiplash.article.summary.domain.document.SummarizedArticle;
-import com.example.whiplash.article.original.domain.entity.UserArticleAssignment;
-import com.example.whiplash.article.summary.repository.SummarizedArticleRepository;
-import com.example.whiplash.article.original.repository.UserArticleAssignmentRepository;
-import com.example.whiplash.domain.entity.history.email.EmailSendStatus;
-import com.example.whiplash.domain.entity.history.email.SummaryLevel;
-import com.example.whiplash.domain.repository.InvestorProfileRepository;
-import com.example.whiplash.user.repository.keyword.UserKeywordRepository;
-import com.example.whiplash.user.domain.User;
-import com.example.whiplash.user.repository.user.UserRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.example.whiplash.article.original.domain.entity.UserArticleAssignment;
+import com.example.whiplash.article.original.repository.UserArticleAssignmentRepository;
+import com.example.whiplash.article.summary.domain.document.Category;
+import com.example.whiplash.article.summary.domain.document.SummarizedArticle;
+import com.example.whiplash.article.summary.repository.SummarizedArticleRepository;
+import com.example.whiplash.domain.entity.history.email.EmailSendStatus;
+import com.example.whiplash.domain.entity.history.email.SummaryLevel;
+import com.example.whiplash.domain.repository.InvestorProfileRepository;
+import com.example.whiplash.user.domain.User;
+import com.example.whiplash.user.repository.keyword.UserKeywordRepository;
+import com.example.whiplash.user.repository.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * ArticleAssignerV2
+ *
+ * V1과 비교
+ * - 필터링할 때 '사용자 관심 카테고리'는 제외한다
+ */
 @Slf4j
 @RequiredArgsConstructor
-@Component("ArticleAssignerV1")
-public class ArticleAssignerV1 implements ArticleAssigner{
+@Component("ArticleAssignerV2")
+public class ArticleAssignerV2 implements ArticleAssigner{
     private final SummarizedArticleRepository summarizedArticleRepository;
     private final UserRepository userRepository;
     private final UserKeywordRepository userKeywordRepository;
@@ -71,18 +80,14 @@ public class ArticleAssignerV1 implements ArticleAssigner{
          변경: insert ignore into를 활용
          **/
         List<String> userKeywords = extractKeywordsFromUser(user);
-        List<Category> userInterestCategories = extractInterestCategoriesFromUser(user);
         SummaryLevel userSummaryLevel = user.getSummaryLevel();
         List<String> assignedSummaryIds = getAlreadyAssignedSummaryIdsByUser(user);
 
         log.info("사용자: {}", user.getName());
         log.info("유저 키워드: {}", userKeywords);
-        log.info("유저 관심 카테고리: {}", userInterestCategories);
         return todaySummaries.stream()
                 // 제목에 키워드 포함
                 .filter(isTitleContainsKeywords(userKeywords))
-                // 카테고리가 일치
-                .filter(isCategoryIncludedIn(userInterestCategories))
                 // 난이도 일치
                 .filter(isLevelEqualsTo(userSummaryLevel))
                 .filter(isAlreadyAssigned(assignedSummaryIds))    //기사 중복 할당 방지
@@ -98,22 +103,15 @@ public class ArticleAssignerV1 implements ArticleAssigner{
         return summary -> summary.getSummaryLevel().equals(userSummaryLevel);
     }
 
-    private static Predicate<SummarizedArticle> isCategoryIncludedIn(List<Category> userInterestCategories) {
-        return summary -> userInterestCategories.contains(summary.getCategory());
-    }
-
     private static Predicate<SummarizedArticle> isTitleContainsKeywords(List<String> userKeywords) {
-        return summary -> userKeywords.stream().anyMatch(keyword -> summary.getTitle().contains(keyword));
+        return summary -> userKeywords.stream()
+            .anyMatch(keyword -> summary.getTitle().contains(keyword));
     }
 
     private List<String> getAlreadyAssignedSummaryIdsByUser(User user) {
         return userArticleAssignmentRepository.findAllByUser(user).stream()
                 .map(userArticleAssignment -> userArticleAssignment.getSummarizedArticleId())
                 .collect(Collectors.toList());
-    }
-
-    private List<Category> extractInterestCategoriesFromUser(User user) {
-        return investorProfileRepository.findByUser(user).orElseThrow().getInterestCategories();
     }
 
     private List<String> extractKeywordsFromUser(User user) {

--- a/src/main/java/com/example/whiplash/delivery/assignment/ArticleAssignerV2.java
+++ b/src/main/java/com/example/whiplash/delivery/assignment/ArticleAssignerV2.java
@@ -6,11 +6,11 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 import com.example.whiplash.article.original.domain.entity.UserArticleAssignment;
 import com.example.whiplash.article.original.repository.UserArticleAssignmentRepository;
-import com.example.whiplash.article.summary.domain.document.Category;
 import com.example.whiplash.article.summary.domain.document.SummarizedArticle;
 import com.example.whiplash.article.summary.repository.SummarizedArticleRepository;
 import com.example.whiplash.domain.entity.history.email.EmailSendStatus;
@@ -31,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @RequiredArgsConstructor
+@Primary
 @Component("ArticleAssignerV2")
 public class ArticleAssignerV2 implements ArticleAssigner{
     private final SummarizedArticleRepository summarizedArticleRepository;
@@ -90,12 +91,12 @@ public class ArticleAssignerV2 implements ArticleAssigner{
                 .filter(isTitleContainsKeywords(userKeywords))
                 // 난이도 일치
                 .filter(isLevelEqualsTo(userSummaryLevel))
-                .filter(isAlreadyAssigned(assignedSummaryIds))    //기사 중복 할당 방지
+                .filter(isNotDuplicatedAssignment(assignedSummaryIds))    //기사 중복 할당 방지
                 .limit(3)
                 .collect(Collectors.toList());
     }
 
-    private static Predicate<SummarizedArticle> isAlreadyAssigned(List<String> assignedSummaryIds) {
+    private static Predicate<SummarizedArticle> isNotDuplicatedAssignment(List<String> assignedSummaryIds) {
         return summary -> !assignedSummaryIds.contains(summary.getId());
     }
 

--- a/src/main/java/com/example/whiplash/delivery/assignment/UserArticleAssignmentService.java
+++ b/src/main/java/com/example/whiplash/delivery/assignment/UserArticleAssignmentService.java
@@ -5,6 +5,8 @@ import com.example.whiplash.article.original.repository.UserArticleAssignmentRep
 import com.example.whiplash.domain.entity.history.email.EmailSendStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Service
 public class UserArticleAssignmentService {
+    @Qualifier("ArticleAssignerV2")
     private final ArticleAssigner assigner;
     private final UserArticleAssignmentRepository assignmentRepository;
 

--- a/src/main/java/com/example/whiplash/delivery/email/SmtpEmailSender.java
+++ b/src/main/java/com/example/whiplash/delivery/email/SmtpEmailSender.java
@@ -1,15 +1,23 @@
 package com.example.whiplash.delivery.email;
 
-
 import com.example.whiplash.article.summary.domain.document.SummarizedArticle;
 import com.example.whiplash.article.summary.repository.SummarizedArticleRepository;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -17,27 +25,54 @@ import java.util.stream.Collectors;
 @Component
 public class SmtpEmailSender implements EmailSender {
 
-    private final JavaMailSender mailSender;
-    private final SummarizedArticleRepository summarizedArticleRepository;
+	private final JavaMailSender mailSender;
+	private final SummarizedArticleRepository summarizedArticleRepository;
+	private final TemplateEngine templateEngine;
 
-    @Override
-    public void sendSummarizedArticlesToUser(String email, List<String> summarizedArticleIds) {
-        List<SummarizedArticle> articles = summarizedArticleRepository.findAllById(summarizedArticleIds);
+	@Override
+	public void sendSummarizedArticlesToUser(String email, List<String> summarizedArticleIds) {
+		log.info("[SmtpEmailSender] 이메일 전송 진입 sendSummarizedArticlesToUser: email: {}, summarizedArticleIds: {}", email, summarizedArticleIds);
+		List<SummarizedArticle> articles = summarizedArticleRepository.findAllById(summarizedArticleIds);
 
-        String content = transformSummaryToContent(articles);
+		Context context = new Context();
+		context.setVariable("publishDate", LocalDate.now().toString());
+		context.setVariable("editorName", "헤드위그");
 
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(email);
-        message.setSubject("오늘의 요약 뉴스입니다");
-        message.setText(content);
+		// 간단 요약 포인트
+		List<String> highlights = articles.stream()
+			.map(article -> article.getTitle())
+			.toList();
+		context.setVariable("highlights", highlights);
 
-        mailSender.send(message);
-        log.info("사용자 {}에게 ArticleAssignment: {}를 이메일로 전송했습니다", email, summarizedArticleIds.stream().map(String::valueOf).collect(Collectors.joining(",")));
-    }
+		// 기사 리스트 매핑
+		List<Map<String, String>> mappedArticles = articles.stream()
+			.map(a -> Map.of(
+				"category", a.getCategory().name(),
+				"title", a.getTitle(),
+				"summary", a.getSummarizedContent(),
+				"summaryLevel", a.getSummaryLevel().name(),
+				"publishedAt", a.getPublishedAt().toLocalDate().toString()
+			))
+			.toList();
 
-    private String transformSummaryToContent(List<SummarizedArticle> articles) {
-        return articles.stream()
-                .map(article -> String.format("!! %s\n%s\n", article.getTitle(), article.getSummarizedContent()))
-                .collect(Collectors.joining("\n\n"));
-    }
+		context.setVariable("articles", mappedArticles);
+
+		// HTML 렌더링
+		String htmlContent = templateEngine.process("newsletter", context);
+
+		try {
+			MimeMessage message = mailSender.createMimeMessage();
+			MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+			helper.setTo(email);
+			helper.setSubject("[Econoesay] 오늘의 요약 뉴스레터");
+			helper.setText(htmlContent, true);
+			mailSender.send(message);
+		} catch (MessagingException e) {
+			throw new RuntimeException("메일 전송 실패", e);
+		}
+
+		log.info("사용자 {}에게 ArticleAssignment: {}를 이메일로 전송했습니다", email,
+			summarizedArticleIds.stream().map(String::valueOf).collect(Collectors.joining(",")));
+	}
+
 }

--- a/src/main/java/com/example/whiplash/delivery/orchestrator/ArticleDeliveryOrchestrator.java
+++ b/src/main/java/com/example/whiplash/delivery/orchestrator/ArticleDeliveryOrchestrator.java
@@ -42,10 +42,11 @@ public class ArticleDeliveryOrchestrator {
             List<String> summaryIdsByUser = assignments.stream()
                     .map(UserArticleAssignment::getSummarizedArticleId)
                     .toList();
-            List<Long> assignmentIdsByUser = assignments.stream()
-                    .map(UserArticleAssignment::getId)
-                    .toList();
             emailService.sendSummarizedArticlesToUser(userId, summaryIdsByUser);
+
+            List<Long> assignmentIdsByUser = assignments.stream()
+                .map(UserArticleAssignment::getId)
+                .toList();
             assignmentService.updateAssignmentStatus(assignmentIdsByUser, EmailSendStatus.SENT);
         });
     }

--- a/src/main/resources/templates/newsletter.html
+++ b/src/main/resources/templates/newsletter.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>EconoEasy Daily Brief</title>
+</head>
+<body style="font-family: 'Apple SD Gothic Neo', sans-serif; background-color: #f9f9f9; margin: 0; padding: 0;">
+<div style="max-width:700px; margin:0 auto; background:#fff; border-radius:12px; padding:40px 32px;">
+
+    <!-- 헤더 -->
+    <div style="text-align:center; margin-bottom:20px;">
+        <p style="font-size:12px; color:#aaa;">이 메일이 잘 안보이시나요?</p>
+        <h1 style="color:#1a237e; font-size:36px; margin:0;">EconoEasy</h1>
+        <p style="color:#1a237e; font-weight:bold;">데일리 | <span th:text="${publishDate}">2025-11-09</span> </p>
+        <p style="font-size:13px; color:#777;">에디터 <span th:text="${editorName}">에디터A</span> </p>
+    </div>
+
+    <!-- 핵심 요약 -->
+    <div style="background:#f6f7fb; padding:18px 22px; border-radius:10px; margin-top:25px;">
+        <p style="font-weight:bold; color:#1a237e; font-size:15px;">💡 이번 주 뉴스레터에는 이런 내용을 담았어요!</p>
+        <ul style="color:#333; font-size:14px; line-height:1.6; margin:0; padding-left:18px;">
+            <li th:each="point : ${highlights}" th:text="${point}">하이라이트 내용</li>
+        </ul>
+    </div>
+
+    <!-- 기사 리스트 -->
+    <div style="margin-top:35px;">
+        <div th:each="article : ${articles}" style="margin-bottom:40px;">
+            <h3 style="color:#1a73e8; margin-bottom:8px;" th:text="${article.category}">카테고리</h3>
+            <h2 style="color:#222; margin:0 0 12px 0;" th:text="${article.title}">기사 제목</h2>
+            <p style="font-size:15px; color:#444; line-height:1.7; white-space:pre-line;" th:text="${article.summary}">요약 내용</p>
+            <p style="font-size:12px; color:#999; margin-top:10px;">
+                📅 <span th:text="${article.publishedAt}">발행일</span> | 요약 수준: <span th:text="${article.summaryLevel}">요약레벨</span>
+            </p>
+            <hr style="border:none; border-top:1px dashed #ddd; margin-top:25px;">
+        </div>
+    </div>
+
+    <!-- 구독 영역 -->
+    <div style="text-align:center; margin-top:40px;">
+        <p style="font-size:14px; color:#555; line-height:1.7;">
+            SNS를 팔로우하면 최신 소식을 가장 빠르게 확인하실 수 있습니다 😆<br>
+            지금 읽고 있는 뉴스레터를 매주 받아보고 싶다면 아래 구독 버튼을 클릭해주세요 😉
+        </p>
+
+        <a href="https://econoeasy.com/subscribe"
+           style="display:inline-block; border:2px solid #1a237e; border-radius:50px;
+                  color:#1a237e; text-decoration:none; padding:10px 28px; font-weight:bold; margin-top:12px;">
+            📩 <span style="font-size:14px;">EconoEasy 구독하기</span>
+        </a>
+
+        <div style="margin-top:25px;">
+            <a href="https://econoeasy.com" style="margin:0 6px;"><img src="https://img.icons8.com/ios-filled/20/1a237e/home.png"/></a>
+            <a href="https://linkedin.com" style="margin:0 6px;"><img src="https://img.icons8.com/ios-filled/20/1a237e/linkedin.png"/></a>
+            <a href="https://instagram.com" style="margin:0 6px;"><img src="https://img.icons8.com/ios-filled/20/1a237e/instagram-new.png"/></a>
+        </div>
+    </div>
+
+    <!-- 푸터 -->
+    <hr style="border:none; border-top:1px solid #eee; margin:40px 0 10px 0;">
+    <div style="text-align:center; font-size:12px; color:#aaa;">
+        <p style="margin:4px 0;">EconoEasy</p>
+        <p style="margin:4px 0;">manager@econoeasy.com</p>
+        <a href="https://econoeasy.com/unsubscribe" style="color:#1a73e8; text-decoration:none;">수신거부 Unsubscribe</a>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
<!-- PR제목 형식
 [PR] #Issue_number: 변경사항 간단 요약
 위의 형식을 사용하여 적어주세요
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  close #Issue_number 
  를 적어주세요 -->
close #61 

## ✨ 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
1. 개인 맞춤형 기사를 이메일 전송 시 html 템플릿으로 제공
- 기존에는 단순히 객체의 데이터만을 넘겼다면 이번 pr이후부터는 html로 렌더링 되는 기사를 받게된다

2. 이메일 전송을 위한 기사할당 작업 시에 `관심 카테고리`는 제거한 `ArticleAssignerV2`를 사용하도록 변경 

## 📸 스크린샷(선택)
<!-- 이해를 돕기위해 사진을 첨부해주세요 -->
