### PR TITLE
[FEATURE] 최근 조회한 기사 목록 조회

### DIFF
--- a/src/main/java/com/example/whiplash/article/original/repository/ArticleReadRedisRepository.java
+++ b/src/main/java/com/example/whiplash/article/original/repository/ArticleReadRedisRepository.java
@@ -3,8 +3,9 @@ package com.example.whiplash.article.original.repository;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Set;
 
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
@@ -14,19 +15,32 @@ import lombok.RequiredArgsConstructor;
 public class ArticleReadRedisRepository {
 	private static final String KEY = "article:read:userId:%d:date:%s";
 
-	private final RedisTemplate<String, Object> redisTemplate;
+	private final StringRedisTemplate redisTemplate;
 
 	public boolean isRead(Long userId, String articleId) {
-		Boolean isRead = redisTemplate.opsForSet().isMember(getKey(userId), articleId);
-		return isRead != null && isRead;
+		Double score = redisTemplate.opsForZSet().score(getKey(userId), articleId);
+		return score != null;
 	}
 
 	public void readArticle(Long userId, String articleId) {
 		String key = getKey(userId);
 
-		redisTemplate.opsForSet().add(key, articleId);
+		// 현재 시간을 timestamp로 사용 (score)
+		double score = (double) System.currentTimeMillis();
+		redisTemplate.opsForZSet().add(key, articleId, score);
 
 		redisTemplate.expire(key, Duration.ofDays(1));
+	}
+
+	public Set<String> getArticleIdsReadByUserOnDate(Long userId, LocalDate date, int limit) {
+		String dateStr = date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+		String key = String.format(KEY, userId, dateStr);
+
+		// ZSET에서 score 내림차순으로 최대 limit개 조회 (최신 순)
+		// reverseRange: 높은 score(최근 시간)부터 반환
+		Set<String> articleIds = redisTemplate.opsForZSet().reverseRange(key, 0, limit - 1);
+
+		return articleIds != null ? articleIds : Set.of();
 	}
 
 	private String getKey(Long userId) {

--- a/src/main/java/com/example/whiplash/article/original/service/ArticleQueryService.java
+++ b/src/main/java/com/example/whiplash/article/original/service/ArticleQueryService.java
@@ -12,6 +12,7 @@ import com.example.whiplash.article.summary.repository.SummarizedArticleReposito
 import com.example.whiplash.article.original.web.dto.response.ArticleDetailResponse;
 import com.example.whiplash.article.original.web.dto.response.ArticleListItemResponse;
 import com.example.whiplash.article.original.web.dto.response.ArticleResponse;
+import com.example.whiplash.article.original.web.dto.response.RecentlyViewedArticleResponse;
 import com.example.whiplash.bookmark.entity.ArticleBookmark;
 import com.example.whiplash.bookmark.repository.ArticleBookmarkRepository;
 import com.example.whiplash.daily.learning.entity.LearningType;
@@ -27,10 +28,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -160,5 +164,36 @@ public class ArticleQueryService {
 	public Page<ArticleListItemResponse> searchArticles(String keyword, Pageable pageable) {
 		Page<Article> articles = articleRepository.searchByKeyword(keyword, pageable);
 		return articles.map(ArticleConverter::toArticleListItemResponse);
+	}
+
+	public List<RecentlyViewedArticleResponse> getRecentlyViewedArticles(Long userId, LocalDate date) {
+		// 1. Redis ZSET에서 최신 10개 기사 ID 조회 (시간순 정렬됨)
+		Set<String> articleIds = articleReadRedisRepository.getArticleIdsReadByUserOnDate(userId, date, 10);
+
+		if (articleIds == null || articleIds.isEmpty()) {
+			log.info("사용자 {}의 {}에 읽은 기사가 없습니다", userId, date);
+			return Collections.emptyList();
+		}
+
+		// 2. MongoDB에서 기사 정보 조회 (배치 쿼리)
+		List<Article> articles = articleRepository.findAllById(articleIds);
+
+		// 3. Redis에서 반환된 순서를 유지하기 위해 Map 생성
+		Map<String, Article> articleMap = articles.stream()
+			.collect(Collectors.toMap(Article::getId, article -> article));
+
+		// 4. Redis 순서대로 DTO 변환 (최신 읽은 순서 유지)
+		List<RecentlyViewedArticleResponse> response = articleIds.stream()
+			.map(articleMap::get)
+			.filter(article -> article != null)  // MongoDB에 없는 기사 필터링
+			.map(article -> RecentlyViewedArticleResponse.builder()
+				.id(article.getId())
+				.title(article.getTitle())
+				.build())
+			.collect(Collectors.toList());
+
+		log.info("✅ 사용자 {}의 {} 최근 조회 기사: {}건", userId, date, response.size());
+
+		return response;
 	}
 }

--- a/src/main/java/com/example/whiplash/article/original/web/controller/ArticleLoadController.java
+++ b/src/main/java/com/example/whiplash/article/original/web/controller/ArticleLoadController.java
@@ -6,6 +6,7 @@ import com.example.whiplash.article.original.service.ArticleQueryService;
 import com.example.whiplash.article.original.web.dto.response.ArticleListItemResponse;
 import com.example.whiplash.article.original.web.dto.response.ArticleListResponse;
 import com.example.whiplash.article.original.web.dto.response.ArticleResponse;
+import com.example.whiplash.article.original.web.dto.response.RecentlyViewedArticleResponse;
 import com.example.whiplash.config.security.UserPrincipal;
 import com.example.whiplash.global.util.SecurityContextUtils;
 
@@ -17,9 +18,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -66,6 +70,18 @@ public class ArticleLoadController {
 		ArticleListResponse response = ArticleListResponse.from(articles);
 
 		return ResponseEntity.ok(ApiResponse.onSuccess(response));
+	}
+
+	@GetMapping("/recently-viewed")
+	public ResponseEntity<ApiResponse<List<RecentlyViewedArticleResponse>>> getRecentlyViewedArticles(
+		@AuthenticationPrincipal UserPrincipal principal,
+		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+
+		Long userId = principal.getUserId();
+
+		List<RecentlyViewedArticleResponse> articles = articleQueryService.getRecentlyViewedArticles(userId, date);
+
+		return ResponseEntity.ok(ApiResponse.onSuccess(articles));
 	}
 
 	/**

--- a/src/main/java/com/example/whiplash/article/original/web/dto/response/RecentlyViewedArticleResponse.java
+++ b/src/main/java/com/example/whiplash/article/original/web/dto/response/RecentlyViewedArticleResponse.java
@@ -1,0 +1,10 @@
+package com.example.whiplash.article.original.web.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record RecentlyViewedArticleResponse(
+	String id,
+	String title
+) {
+}

--- a/src/main/java/com/example/whiplash/domain/entity/SuperBaseEntity.java
+++ b/src/main/java/com/example/whiplash/domain/entity/SuperBaseEntity.java
@@ -1,26 +1,27 @@
 package com.example.whiplash.domain.entity;
 
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import java.time.LocalDateTime;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @MappedSuperclass // JPA에서 상속받는 클래스의 공통 필드들을 테이블 컬럼으로 인식하게 해주는 어노테이션
 @Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseEntity {
+public class SuperBaseEntity {
+	@CreatedDate
+	private LocalDateTime createdAt;
 
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/example/whiplash/log/quiz/entity/QuizSolveLog.java
+++ b/src/main/java/com/example/whiplash/log/quiz/entity/QuizSolveLog.java
@@ -1,6 +1,8 @@
 package com.example.whiplash.log.quiz.entity;
 
 import com.example.whiplash.domain.entity.BaseEntity;
+import com.example.whiplash.domain.entity.SuperBaseEntity;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,7 +23,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 @Entity
-public abstract class QuizSolveLog extends BaseEntity {
+public abstract class QuizSolveLog extends SuperBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)


### PR DESCRIPTION
<!-- PR제목 형식
 [PR] #Issue_number: 변경사항 간단 요약
 위의 형식을 사용하여 적어주세요
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  close #Issue_number 
  를 적어주세요 -->
close #87 

## ✨ 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
1. `/api/articles/recently-viewed` 엔드포인트 구현
- 요청한 사용자가 최근 조회한 기사를 최대 10개 조회한다

읽은 기사를 저장할 자료구조를 redis SET -> ZSET으로 변경하여 최근 조회한 순으로 조회할 수 있도록 수정

## 📸 스크린샷(선택)
<!-- 이해를 돕기위해 사진을 첨부해주세요 -->
